### PR TITLE
Text info, which outputs on top of p4 form, has been extracted

### DIFF
--- a/p4.el
+++ b/p4.el
@@ -287,6 +287,12 @@ window, or NIL to display it in the echo area.")
 (defvar p4-form-committed nil "Form successfully committed?")
 (defvar p4-form-commit-fail-callback nil
   "Function run if commit fails.")
+(defvar p4-form-head-text
+  (format "# Created using %s.
+# Type C-c C-c to send the form to the server.
+# Type C-x k to cancel the operation.
+#\n" (p4-version))
+    "Head text which outputs on top of p4 form.")
 
 ;; Local variables in P4 depot buffers.
 (defvar p4-default-directory nil "Original value of default-directory.")
@@ -1093,10 +1099,7 @@ opposed to showing it in the echo area)."
   ;; The Windows p4 client outputs this line before the spec unless
   ;; run via CMD.EXE.
   (when (looking-at "Found client MATCH : .*\n") (replace-match ""))
-  (insert "# Created using " (p4-version) ".\n"
-          "# Type C-c C-c to send the form to the server.\n"
-          "# Type C-x k to cancel the operation.\n"
-          "#\n")
+  (insert p4-form-head-text)
   (p4-form-mode)
   (pop-to-buffer (current-buffer))
   (setq p4-form-commit-command cmd)


### PR DESCRIPTION
Text info, which outputs on top of p4 form, has been extracted to the separated variable: p4-form-head-text.

I need possibility to change head text which could contains additional shortcuts (not only "C-c C-c" and "C-x k").
