### PR TITLE
Make RET goto source file

### DIFF
--- a/p4.el
+++ b/p4.el
@@ -3615,6 +3615,7 @@ REVERSE is non-NIL. The location in the file can be found by
 going to line number LINE and then moving forward OFFSET
 characters."
   (save-excursion
+    (goto-char (point-min))
     (let* ((char-offset (- (point) (diff-beginning-of-hunk t)))
            (_ (diff-sanity-check-hunk))
            (hunk (buffer-substring


### PR DESCRIPTION
Currently when typing RET in a diff buffer, I get 
"Can't find filespec(s) in diff file header."
The reason is that the point is not positioned at the header.
