### PR TITLE
Make p4 ediff show depot file on left pane

### DIFF
--- a/p4.el
+++ b/p4.el
@@ -1778,7 +1778,7 @@ buffer and the P4 output buffer."
       (when (buffer-live-p orig-buffer)
         (p4-fontify-print-buffer t)
         (lexical-let ((depot-buffer (current-buffer)))
-          (ediff-buffers orig-buffer depot-buffer))))))
+          (ediff-buffers depot-buffer orig-buffer))))))
 
 (defun p4-ediff (prefix)
   "Use ediff to compare file with its original client version."


### PR DESCRIPTION
The choice is arbitrary, but matches what p4merge and ediff-against-revision do already.
It can be made customizable, if that is preferred.
