### PR TITLE
Ignore P4DIFF and DIFF in p4-revert

### DIFF
--- a/p4.el
+++ b/p4.el
@@ -2117,7 +2117,13 @@ changelist."
   (let ((prompt t))
     (unless args-orig
       (let* ((diff-args (append (cons "diff" (p4-make-list-from-string p4-default-diff-options)) args))
-             (inhibit-read-only t))
+             (inhibit-read-only t)
+             ;; We need 'p4 diff' to return a text response in order to populate
+             ;; the diff buffer.  If P4DIFF or DIFF refer to a graphical diff
+             ;; tool, then things may not behave as expected. This line removes
+             ;; the P4DIFF and DIFF variables from the environment, which should
+             ;; force 'p4 diff' to return a textual response.
+             (process-environment (cl-list* "P4DIFF" "DIFF" process-environment)))
         (with-current-buffer
             (p4-make-output-buffer (p4-process-buffer-name diff-args)
                                    'p4-diff-mode)


### PR DESCRIPTION
p4-revert runs 'p4 diff' and expects a textual diff response. This
assumption is violated if P4DIFF points to a graphical diff tool, which
may not return a textual diff. The same behavior happens if P4DIFF is not
set and DIFF points to a graphical diff tool, since p4 falls back to using
DIFF.

We fix this by clearing the P4DIFF and DIFF variables from the local
environment before running 'p4 diff'. This behavior change only applies
to the p4-revert function.

Fixes #239 