### PR TITLE
Escape @ characters as %40

### DIFF
--- a/p4.el
+++ b/p4.el
@@ -864,7 +864,7 @@ characters."
   "Return name of file BUFFER is visiting, or NIL if none,
 respecting the `p4-follow-symlinks' setting."
   (let ((f (buffer-file-name buffer)))
-    (when f (p4-follow-link-name f))))
+    (when f (replace-regexp-in-string "@" "%40" (p4-follow-link-name f)))))
 
 (defun p4-process-output (cmd &rest args)
   "Run CMD (with the given ARGS) and return the output as a string,


### PR DESCRIPTION
We use Matlab, Matlab loves using @ in direcory names, Perforce does
not. This will simple replace the @ with the %40 escape code.

If i was better at elisp i would handle every character which needs to
be escaped:

https://www.perforce.com/perforce/r12.1/manuals/cmdref/o.fspecs.html

I would probably also add a p4-escape-name function which does the
work.